### PR TITLE
Implement `len()` to return the size of a table

### DIFF
--- a/grnpy/grn_table.pxd
+++ b/grnpy/grn_table.pxd
@@ -40,3 +40,6 @@ cdef extern from "groonga.h":
                               grn_table_flags flags,
                               grn_obj *key_type,
                               grn_obj *value_type)
+
+    unsigned int grn_table_size(grn_ctx *ctx,
+                                grn_obj *table)

--- a/grnpy/table.pyx
+++ b/grnpy/table.pyx
@@ -35,7 +35,7 @@ import grnpy.context
 cdef class Table(Object):
     def __len__(self):
         cdef Context context = self._context
-        return grnpy.grn_table.grn_table_size(context.unwrap(), self._obj)
+        return grnpy.grn_table.grn_table_size(context.unwrap(), self.unwrap())
 
     @classmethod
     def _create(cls,

--- a/grnpy/table.pyx
+++ b/grnpy/table.pyx
@@ -33,6 +33,10 @@ from .error import Error
 import grnpy.context
 
 cdef class Table(Object):
+    def __len__(self):
+        cdef Context context = self._context
+        return grnpy.grn_table.grn_table_size(context.unwrap(), self._obj)
+
     @classmethod
     def _create(cls,
                 grnpy.grn_table.grn_table_flags flags,

--- a/testing/test_table.py
+++ b/testing/test_table.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2026  Abe Tomoaki <abe@clear-code.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+
+import grnpy
+
+def test_len_empty(tmpdir):
+    db_path = tmpdir.join('db')
+    with grnpy.Database.create(db_path):
+        users = grnpy.PatriciaTrie.create('ShortText', 'Users')
+        assert len(users) == 0


### PR DESCRIPTION
Since there is no implementation for the method that add data, there is only a test for 0.
We will add tests once we implement the add() method.